### PR TITLE
Implemented StringExtensions.Truncate() method

### DIFF
--- a/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
+++ b/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
@@ -40,14 +40,14 @@ namespace Deltatre.Utils.Extensions.String
       if (string.IsNullOrWhiteSpace(source))
         return source;
 
-      if (source.Length > length)
-      {
-        source = source.Substring(0, length);
-      }
-      if (string.IsNullOrWhiteSpace(ellipsis))
-      {
+      if (source.Length <= length)
         return source;
-      }
+
+      source = source.Substring(0, length);
+
+      if (string.IsNullOrWhiteSpace(ellipsis))
+        return source;
+
       return string.Concat(source, ellipsis);
     }
   }

--- a/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
+++ b/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
@@ -27,9 +27,10 @@ namespace Deltatre.Utils.Extensions.String
     }
 
     /// <summary>
-    /// Truncat method, tests the length of the source string to see if it needs any processing. 
+    /// This method is meant to return a string with a specific length.
+    /// It tests the length of the source string to see if it needs any processing. 
     /// If the source is longer than the max length, we call Substring to get the first N characters. 
-    /// This copies the string.
+    /// The method copies the string.
     /// </summary>
     /// <param name="source">The string to be sanitized from HTML tags</param>
     /// <param name="length">The max length of the source</param>

--- a/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
+++ b/src/Deltatre.Utils/Extensions/String/StringExtensions.cs
@@ -25,5 +25,30 @@ namespace Deltatre.Utils.Extensions.String
 
       return HtmlTagRegex.Replace(source, string.Empty);
     }
+
+    /// <summary>
+    /// Truncat method, tests the length of the source string to see if it needs any processing. 
+    /// If the source is longer than the max length, we call Substring to get the first N characters. 
+    /// This copies the string.
+    /// </summary>
+    /// <param name="source">The string to be sanitized from HTML tags</param>
+    /// <param name="length">The max length of the source</param>
+    /// <param name="ellipsis">Value to add at the end of the returned string</param>
+    /// <returns></returns>
+    public static string Truncate(this string source, int length = 150, string ellipsis = "...")
+    {
+      if (string.IsNullOrWhiteSpace(source))
+        return source;
+
+      if (source.Length > length)
+      {
+        source = source.Substring(0, length);
+      }
+      if (string.IsNullOrWhiteSpace(ellipsis))
+      {
+        return source;
+      }
+      return string.Concat(source, ellipsis);
+    }
   }
 }

--- a/tests/Deltatre.Utils.Tests/Extensions/String/StringExtensionsTest.cs
+++ b/tests/Deltatre.Utils.Tests/Extensions/String/StringExtensionsTest.cs
@@ -110,7 +110,7 @@ namespace Deltatre.Utils.Tests.Extensions.String
     public void Truncate_Returns_Truncate_String_With_Ellipsis_String_At_The_End()
     {
       // ARRANGE
-      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
+      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.";
 
       // ACT
       var result = source.Truncate(50);
@@ -125,7 +125,7 @@ namespace Deltatre.Utils.Tests.Extensions.String
     public void Truncate_Returns_Truncate_String_With_No_Ellipsis_String_At_The_End_If_Null_Or_Whitespace()
     {
       // ARRANGE
-      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
+      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry.";
 
       // ACT
       var result = source.Truncate(50, "");

--- a/tests/Deltatre.Utils.Tests/Extensions/String/StringExtensionsTest.cs
+++ b/tests/Deltatre.Utils.Tests/Extensions/String/StringExtensionsTest.cs
@@ -68,5 +68,72 @@ namespace Deltatre.Utils.Tests.Extensions.String
       const string expectedString = "When you want to include literal html inside a web page you should encode it (e.g.: &lt;h1&gt; Title here &lt;/h1&gt;)";
       Assert.AreEqual(expectedString, result);
     }
+
+    [Test]
+    public void Truncate_Returns_Null_For_Null_Source()
+    {
+      // ACT
+      var result = StringExtensions.Truncate(null);
+
+      // ASSERT
+      Assert.IsNull(result);
+    }
+
+
+    [Test]
+    public void Truncate_Returns_Empty_String_For_Empty_String_Source()
+    {
+      // ACT
+      var result = string.Empty.Truncate();
+
+      // ASSERT
+      Assert.IsNotNull(result);
+      Assert.IsEmpty(result);
+    }
+
+    [Test]
+    public void Truncate_Returns_Original_String_If_Minor_Or_Equal_To_Lenght_Params()
+    {
+      // ARRANGE
+      const string source = "Lorem ipsum dolor sit amet, consectetur cras amet.";
+
+      // ACT
+      var result = source.Truncate(100);
+
+      // ASSERT
+      Assert.IsNotNull(result);
+      const string expectedString = "Lorem ipsum dolor sit amet, consectetur cras amet.";
+      Assert.AreEqual(expectedString, result);
+    }
+
+    [Test]
+    public void Truncate_Returns_Truncate_String_With_Ellipsis_String_At_The_End()
+    {
+      // ARRANGE
+      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
+
+      // ACT
+      var result = source.Truncate(50);
+
+      // ASSERT
+      Assert.IsNotNull(result);
+      const string expectedString = "Lorem Ipsum is simply dummy text of the printing a...";
+      Assert.AreEqual(expectedString, result);
+    }
+
+    [Test]
+    public void Truncate_Returns_Truncate_String_With_No_Ellipsis_String_At_The_End_If_Null_Or_Whitespace()
+    {
+      // ARRANGE
+      const string source = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
+
+      // ACT
+      var result = source.Truncate(50, "");
+
+      // ASSERT
+      Assert.IsNotNull(result);
+      const string expectedString = "Lorem Ipsum is simply dummy text of the printing a";
+      Assert.AreEqual(expectedString, result);
+    }
   }
 }


### PR DESCRIPTION
The `StringExtensions.Truncate()` method is meant to return a string with a specific length, with an optional suffix (ex: "...").
This could be useful when we should render an excerpt of paragraph or when dealing with SEO meta tags. 
