### PR TITLE
Added overload to OperationResult.CreateFailure

### DIFF
--- a/src/Deltatre.Utils/Dto/OperationResult_WithError.cs
+++ b/src/Deltatre.Utils/Dto/OperationResult_WithError.cs
@@ -29,6 +29,21 @@ namespace Deltatre.Utils.Dto
 		}
 
 		/// <summary>
+		/// Call this method to create an instance representing the result of a failed operation.
+		/// </summary>
+		/// <param name="error">The detected error</param>
+		/// <exception cref="ArgumentNullException">Throws ArgumentNullException when parameter errors is null</exception>
+		/// <returns>An instance representing the result of a failed operation.</returns>
+		/// <remarks>Property Output will be set equal to the default value of type TOutput.</remarks>
+		public static OperationResult<TOutput, TError> CreateFailure(TError error)
+		{
+			if (error == null)
+				throw new ArgumentNullException(nameof(error));
+
+			return CreateFailure(new NonEmptySequence<TError>(new[] { error }));
+		}
+
+		/// <summary>
 		/// Call this method to create an instance representing the result of a successful operation. The list of errors will be set to an empty list.
 		/// </summary>
 		/// <param name="output">The operation output.</param>

--- a/tests/Deltatre.Utils.Tests/Dto/OperationResultTest_WithErrors.cs
+++ b/tests/Deltatre.Utils.Tests/Dto/OperationResultTest_WithErrors.cs
@@ -2,6 +2,7 @@
 using Deltatre.Utils.Dto;
 using NUnit.Framework;
 using Deltatre.Utils.Extensions.Enumerable;
+using Deltatre.Utils.Types;
 
 namespace Deltatre.Utils.Tests.Dto
 {
@@ -9,14 +10,19 @@ namespace Deltatre.Utils.Tests.Dto
 	public class OperationResultWithErrorsTest
 	{
 		[Test]
-		public void CreateFailure_Throws_When_Errros_Is_Null()
+		public void CreateFailure_Throws_When_Errors_Is_Null()
 		{
+			// ARRANGE
+			const string nullString = null;
+			NonEmptySequence<string> nullSequence = null;
+
 			// ACT
-			Assert.Throws<ArgumentNullException>(() => OperationResult<string, string>.CreateFailure(null));
+			Assert.Throws<ArgumentNullException>(() => OperationResult<string, string>.CreateFailure(nullString));
+			Assert.Throws<ArgumentNullException>(() => OperationResult<string, string>.CreateFailure(nullSequence));
 		}
 
 		[Test]
-		public void CreateFailure_Allows_To_Create_Failure_Result_With_Errors()
+		public void CreateFailure_Allows_To_Create_Failure_Result_With_Errors_Providing_A_NonEmptySequence()
 		{
 			// ARRANGE
 			var errors = new[] { "something bad occurred", "invalid prefix detected" }.ToNonEmptySequence();
@@ -30,6 +36,24 @@ namespace Deltatre.Utils.Tests.Dto
 			Assert.IsNull(result.Output);
 			Assert.IsNotNull(result.Errors);
 			CollectionAssert.AreEqual(errors, result.Errors);
+		}
+
+		[Test]
+		public void CreateFailure_Allows_To_Create_Failure_Result_With_Error_Providing_An_Error_Object()
+		{
+			// ARRANGE
+			const string error = "something bad occurred";
+
+			// ACT
+			var result = OperationResult<string, string>.CreateFailure(error);
+
+			// ASSERT
+			Assert.IsNotNull(result);
+			Assert.IsFalse(result.IsSuccess);
+			Assert.IsNull(result.Output);
+			Assert.IsNotNull(result.Errors);
+			Assert.IsNotEmpty(result.Errors);
+			CollectionAssert.AreEqual(error, result.Errors[0]);
 		}
 
 		[Test]


### PR DESCRIPTION
The overload allows to provide just one object instead of a sequence, this can be handy when the operation produces just one error, in this way the OperationResult object creation is less verbose